### PR TITLE
Fix system rspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ group :development, :test do
   gem "webmock"
   gem 'capybara'
   gem 'selenium-webdriver'
+  gem 'rspec-retry'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,6 +186,8 @@ GEM
       rspec-expectations (~> 3.8.0)
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
+    rspec-retry (0.6.1)
+      rspec-core (> 3.3)
     rspec-support (3.8.2)
     rubocop (0.74.0)
       jaro_winkler (~> 1.5.1)
@@ -252,6 +254,7 @@ DEPENDENCIES
   rails-controller-testing
   rmagick
   rspec-rails
+  rspec-retry
   rubocop
   selenium-webdriver
   tzinfo-data

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -74,6 +74,14 @@ RSpec.configure do |config|
     end
   end
 
+  config.verbose_retry = true
+  config.display_try_failure_messages = true
+  config.default_retry_count = 3
+
+  config.before(:all, type: :system) do
+    timestamp!
+  end
+
   # Capybara setting
   config.before(:each, type: :system) do
     driven_by Capybara.default_driver

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,11 +1,15 @@
 Capybara.default_driver    = :selenium_chrome
 Capybara.javascript_driver = :selenium_chrome
-Capybara.server_host = Socket.ip_address_list.detect{|addr| addr.ipv4_private?}.ip_address
+Capybara.server_host = Socket.ip_address_list.detect(&:ipv4_private?).ip_address
 Capybara.server_port = 3001
 Capybara.default_max_wait_time = 5
+Capybara.ignore_hidden_elements = true
 
 Capybara.register_driver :selenium_chrome do |app|
-  # settign url to chrome container
-  url = "http://chrome:4444/wd/hub"
-  Capybara::Selenium::Driver.new(app, desired_capabilities: :chrome, browser: :remote, url: url)
+  opts = {
+    desired_capabilities: :chrome,
+    browser:              :remote,
+    url:                  "http://chrome:4444/wd/hub",
+  }
+  Capybara::Selenium::Driver.new(app, opts)
 end

--- a/spec/support/system_support.rb
+++ b/spec/support/system_support.rb
@@ -1,4 +1,12 @@
 module SystemSupport
+  def timestamp!(timestamp = Time.now.to_i)
+    @timestamp = timestamp
+  end
+
+  def timestamp
+    @timestamp
+  end
+
   # give me block return boolean
   def wait_until(wait_time = Capybara.default_max_wait_time)
     Timeout.timeout(wait_time) do

--- a/spec/system/hello_worlds_spec.rb
+++ b/spec/system/hello_worlds_spec.rb
@@ -33,79 +33,72 @@ RSpec.describe "HelloWorlds", type: :system, js: true do
     end
   end
 
-  context "when go to Create page" do
+  context "when create update delete" do
     after {
-      HelloWorld.find_by(country: "DE").try(:destroy)
+      HelloWorld.where("hello like '%#{timestamp}%' ").try(:delete_all)
     }
-    it "create content" do
-      page.first("#new_hello_world").click
-      wait_until { page.has_css?("h3", text: "New Helloworld") }
+    context "when go to Create page" do
+      it "create content" do
+        page.first("#new_hello_world").click
+        wait_until { page.has_css?("h3", text: "New Helloworld") }
 
-      # input form
-      select "ドイツ", from: "hello_world_country"
-      fill_in "hello_world_hello", with: "Hallo Welt"
-      fill_in "hello_world_priority", with: 4
+        # input form
+        select "ドイツ", from: "hello_world_country"
+        fill_in "hello_world_hello", with: "Hallo Welt #{timestamp}"
+        fill_in "hello_world_priority", with: 4
 
-      click_on "Submit"
+        click_on "Submit"
 
-      wait_until { page.has_content?("Hello world was successfully created.") }
+        wait_until { page.has_content?("Hello world was successfully created.") }
 
-      content = page.first("div.form").all("label.form-control")
-      expect(content[0].text).to eq("ドイツ")
-      expect(content[1].text).to eq("Hallo Welt")
-      expect(content[2].text).to eq("4")
+        content = page.first("div.form").all("label.form-control")
+        expect(content[0].text).to eq("ドイツ")
+        expect(content[1].text).to eq("Hallo Welt #{timestamp}")
+        expect(content[2].text).to eq("4")
+      end
     end
-  end
 
-  context "when go to Edit page" do
-    let!(:content) { create(:hello_world, country: "DE", hello: "Hallo Welt", priority: 4) }
-    before(:each) {
-      visit root_path
-      wait_until { (page.all("div.portfolio-item").count == 4) }
-    }
-    after {
-      HelloWorld.find_by(country: "DE").try(:destroy)
-    }
-    it "edit content" do
-      wait_until {
-        sleep 0.1 # すげえ不本意
-        page.has_css?("a#edit_#{content.id}")
+    context "when go to Edit page" do
+      let!(:hr) { create(:hello_world, country: "DE", hello: "Hallo Welt Edit #{timestamp}", priority: 4) }
+      before(:each) {
+        visit root_path
+        wait_until { (page.all("div.portfolio-item").count == 4) }
       }
-      page.first("a#edit_#{content.id}").click
-      wait_until { page.has_css?("h3", text: "Edit Helloworld") }
+      it "edit content" do
+        wait_until { page.has_css?("a#edit_#{hr.id}") }
+        page.first("a#edit_#{hr.id}").click
+        wait_until { page.has_css?("h3", text: "Edit Helloworld") }
 
-      # input form
-      fill_in "hello_world_hello", with: "Update Hallo Welt"
+        # input form
+        fill_in "hello_world_hello", with: "Update Hallo Welt #{timestamp}"
 
-      click_on "Submit"
+        click_on "Submit"
 
-      wait_until { page.has_content?("Hello world was successfully updated.") }
+        wait_until { page.has_content?("Hello world was successfully updated.") }
 
-      content = page.first("div.form").all("label.form-control")
-      expect(content[0].text).to eq("ドイツ")
-      expect(content[1].text).to eq("Update Hallo Welt")
-      expect(content[2].text).to eq("4")
+        content = page.first("div.form").all("label.form-control")
+        expect(content[0].text).to eq("ドイツ")
+        expect(content[1].text).to eq("Update Hallo Welt #{timestamp}")
+        expect(content[2].text).to eq("4")
+      end
     end
-  end
 
-  context "when exec Delete" do
-    let!(:content) { create(:hello_world, country: "DE", hello: "Hallo Welt", priority: 4) }
-    before(:each) {
-      visit root_path
-      wait_until { (page.all("div.portfolio-item").count == 4) }
-    }
-    it "edit content" do
-      wait_until {
-        sleep 0.1 # すげえ不本意
-        page.has_css?("a#delete_#{content.id}")
+    context "when exec Delete" do
+      let!(:hr) { create(:hello_world, country: "DE", hello: "Hallo Welt Delete #{timestamp}", priority: 4) }
+      before(:each) {
+        visit root_path
+        wait_until { (page.all("div.portfolio-item").count == 4) }
       }
-      page.first("a#delete_#{content.id}").click
-      wait_until { page.has_css?("h2#swal2-title", text: "Delete Content") }
-      click_on "Sure"
-      wait_until { page.has_css?("h2#swal2-title", text: "Deleted successfully!") }
-      click_on "OK"
+      it "edit content", retry: 5 do
+        wait_until { page.has_css?("a#delete_#{hr.id}") }
+        page.first("a#delete_#{hr.id}").click
+        wait_until { page.has_css?("h2#swal2-title", text: "Delete Content") }
+        click_on "Sure"
+        wait_until { page.has_css?("h2#swal2-title", text: "Deleted successfully!") }
+        click_on "OK"
 
-      wait_until { (page.all("div.portfolio-item").count == 3) }
+        wait_until { (page.all("div.portfolio-item").count == 3) }
+      end
     end
   end
 end


### PR DESCRIPTION
#32 の追加対応

- テストが不安定なのでretry-specで逃げる。ほんとCapybara嫌い。
- timestampでdescribe毎にテストで共通の一位になる値を定義。これで名前衝突回避できるし、色々応用効くので地味に便利